### PR TITLE
bugfix: capture numbers with commas in them

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -119,7 +119,7 @@ class GoogleNews:
         self.content = Soup(self.page, "html.parser")
         stats = self.content.find_all("div", id="result-stats")
         if stats and isinstance(stats, ResultSet):
-            stats = re.search(r'\d+', stats[0].text)
+            stats = re.search(r'[\d,]+', stats[0].text)
             self.__totalcount = int(stats.group())
         else:
             #TODO might want to add output for user to know no data was found


### PR DESCRIPTION
Sometimes the `result-stats` div has a number in the thousands that displays like "**About 42,900 results**". Currently, this is returned as 42 in the total_counts function, this will fix that to return 42900.

Thanks!