### PR TITLE
Update __init__.py

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -3,6 +3,7 @@
 import re
 import urllib.request
 import dateparser, copy
+import requests
 from bs4 import BeautifulSoup as Soup, ResultSet
 from dateutil.parser import parse
 
@@ -288,12 +289,16 @@ class GoogleNews:
                     # link
                     if deamplify:
                         try:
-                            link = 'news.google.com/' + article.find("h3").find("a").get("href")
+                            link = 'https://news.google.com/' + article.find("h3").find("a").get("href")
+                            r = requests.head(link, allow_redirects=True)
+                            link = r.url
                         except Exception as deamp_e:
                             print(deamp_e)
                             link = article.find("article").get("jslog").split('2:')[1].split(';')[0]
                     else:
-                            link = 'news.google.com/' + article.find("h3").find("a").get("href")
+                            link = 'https://news.google.com/' + article.find("h3").find("a").get("href")
+                            r = requests.head(link, allow_redirects=True)
+                            link = r.url
                     self.__texts.append(title)
                     self.__links.append(link)
                     if link.startswith('https://www.youtube.com/watch?v='):


### PR DESCRIPTION
Currently all links from this package result in a link similar to:

news.google.com/./articles/CAIiEMOJAsGEHwx_2WzzLm2QVtQqFQgEKg0IACoGCAowrqkBMKBFMLKAAg?uo=CAUiZmh0dHBzOi8vd3d3LmZvcmJlcy5jb20vc2l0ZXMvam9ubWFya21hbi8yMDIyLzAxLzMxL2FwcGxlcy1ibG93b3V0LWVhcm5pbmdzLXByb3ZlLWl0cy1zaGFyZXMtYXJlLWNoZWFwL9IBAA&hl=en-US&gl=US&ceid=US%3Aen

Which may not be the ideal use case for many people who intend to scrape for links.  By pre-pending the link to specifically only reach out with HTTPS and importing requests, we can follow the Google redirect and fetch the actual URL, which ends up being:

https://www.forbes.com/sites/jonmarkman/2022/01/31/apples-blowout-earnings-prove-its-shares-are-cheap/?sh=36000f192c73

Tested by importing branch in a Python3 virtual environment and 

pip install -e .