### PR TITLE
Removed the code that replaces space to +

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -125,7 +125,7 @@ class GoogleNews:
         Parameters:
         key = the search term
         """
-        self.__key = "+".join(key.split(" "))
+        self.__key = key
         if self.__encode != "":
             self.__key = urllib.request.quote(self.__key.encode(self.__encode))
         self.get_page()
@@ -264,8 +264,7 @@ class GoogleNews:
     def get_news(self, key="",deamplify=False):
         if key != '':
             if self.__period != "":
-                key += f"+when:{self.__period}"
-            key = "+".join(key.split(" "))
+                key += f" when:{self.__period}"
         else:
             if self.__period != "":
                 key += f"when:{self.__period}"


### PR DESCRIPTION
While encoding the query/key, replacing space with + was responsible for two main problems
1.  Users were not able to use phrases properly (issues #109 and #107). 
2.  Users were not able to use additional techniques to refine their searches (issue #66)

This simple change resolves both issues and works for both search and get_news functions.
 