### PR TITLE
Update __init__.py

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -311,7 +311,7 @@ class GoogleNews:
                             link = article.find("article").get("jslog").split('2:')[1].split(';')[0]
                     else:
                         try:
-                            link = 'news.google.com/' + article.find("h4").parent.get("href")[2:]
+                            link = 'news.google.com/' + article.find("a").get("href")[2:]
                         except Exception as deamp_e:
                             print(deamp_e)
                             link = None


### PR DESCRIPTION
Removed find for 'h4' as it is not present in the article, instead finding 'a' and getting the href from it. 
I tested with ~50 articles and this pulled the correct URL, but I do not know: 

- if "a" class always has the URL 
- if the URL is always stored as href
- if there was a change in how Google News was returning articles that caused this error to occur
- if this should also be added to deamplified links