### PR TITLE
Fixed malformed title

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -282,7 +282,7 @@ class GoogleNews:
                 try:
                     # title
                     try:
-                        title=article.findAll('div')[2].text
+                        title=article.findAll('div')[3].find('a').text
                     except:
                         title=None
                     # description


### PR DESCRIPTION
As of 1.6.12 I began getting malformed titles like "Sitename.comMoreActual Title", digging the text from the anchor rather than the div fixed it for me.