### PR TITLE
Fix get_news function with only period parameter specifies

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -272,7 +272,13 @@ class GoogleNews:
         key = urllib.request.quote(key.encode(self.__encode))
         start = f'{self.__start[-4:]}-{self.__start[:2]}-{self.__start[3:5]}'
         end = f'{self.__end[-4:]}-{self.__end[:2]}-{self.__end[3:5]}'
-        self.url = 'https://news.google.com/search?q={}+before:{}+after:{}&hl={}'.format(key,end, start, self.__lang.lower())
+        
+        if self.__start == '' or self.__end == '':
+            self.url = 'https://news.google.com/search?q={}&hl={}'.format(
+                key, self.__period, self.__lang.lower())
+        else:
+            self.url = 'https://news.google.com/search?q={}+before:{}+after:{}&hl={}'.format(
+                key, end, start, self.__lang.lower())
 
         try:
             self.req = urllib.request.Request(self.url, headers=self.headers)


### PR DESCRIPTION
get_news() fetches results from news.google.com. While a user initiates a GoogleNews object with only 'period' specified (but not start & end dates specified), get_news() will still insert the start and end dates in the search keyword.
```
start = f'{self.__start[-4:]}-{self.__start[:2]}-{self.__start[3:5]}'
end = f'{self.__end[-4:]}-{self.__end[:2]}-{self.__end[3:5]}'
```
```
self.url = 'https://news.google.com/search?q={}+before:{}+after:{}&hl={}'.format(key, end, start, self.__lang.lower())
```
In this way, news.google.com will return empty or incomplete results.
For example:
```
googlenews = GoogleNews()
googlenews = GoogleNews(lang='en', region='US')
googlenews = GoogleNews(period='1d')
googlenews.get_news('Dearborn')
```
```
print(self.url)
# https://news.google.com/search?q=Dearborn%20when%3A1d+before:--+after:--&hl=en
```
Trying this URL will show no results. without before and after in the keywords, the URL will be like:
https://news.google.com/search?q=Dearborn+when:1d&hl=en-US&gl=US&ceid=US:en
This will show correct list of results.