### PR TITLE
Correction of get_news function for the period parameter

### DIFF
--- a/GoogleNews/__init__.py
+++ b/GoogleNews/__init__.py
@@ -281,7 +281,7 @@ class GoogleNews:
         
         if self.__start == '' or self.__end == '':
             self.url = 'https://news.google.com/search?q={}&hl={}'.format(
-                key, self.__period, self.__lang.lower())
+                key, self.__lang.lower())
         else:
             self.url = 'https://news.google.com/search?q={}+before:{}+after:{}&hl={}'.format(
                 key, end, start, self.__lang.lower())


### PR DESCRIPTION
I noticed that when passing the period parameter, the language was not considered anymore, even if specified.
I found out that in the `get_news` function, at line 284:
```python
if self.__start == '' or self.__end == '':
    self.url = 'https://news.google.com/search?q={}&hl={}'.format(
        key, self.__period, self.__lang.lower())
```
the `self.__period` parameter was passed instead of the language, while the period is not needed since it's already encoded in the `key` parameter.

I also run the tests to check that my change would not break the code and they passed.

Tell me if there is any problem and thank you for this great library!